### PR TITLE
have PostData::dataClass return static instead of self by default

### DIFF
--- a/src/PostData.php
+++ b/src/PostData.php
@@ -94,7 +94,7 @@ class PostData extends Data implements PostDataInterface
             return $classes[$postType];
         }
 
-        return self::class;
+        return static::class;
     }
 
     private function metaPrefix(): string


### PR DESCRIPTION
Door _by default_ `static` in plaats van `self` te return'en, kun je, als bijv. class `NewsData` `Yard\Data\PostData` extend't, met `NewsData::fromPost($post)` een `NewsData`-object krijgen zonder dat je dat betreffende post-type in config-file `config/yard-data.php` hoeft te declareren. (En dat is sowieso handig, en helemaal wanneer je dit in een plugin of package wilt doen.)